### PR TITLE
remove unused /app route reference

### DIFF
--- a/parkquest-frontend/src/App.jsx
+++ b/parkquest-frontend/src/App.jsx
@@ -29,11 +29,18 @@ function App() {
         setIsAuthenticated(!!token); // Set authentication based on token presence
     }, []);
 
+    useEffect(() => {
+      const token = localStorage.getItem("authToken");
+      if (token && location.pathname === "/") {
+        navigate("/dashboard");
+      }
+    }, [location, navigate]);
+
     // Log the user out when the token becomes invalid
   const handleLogout = () => {
     localStorage.removeItem("authToken");
     setIsAuthenticated(false); // Update auth state
-    navigate("/App");
+    navigate("/");
   };
 
   return (
@@ -58,7 +65,6 @@ function App() {
                 path="/login"
                 element={<Login setIsAuthenticated={setIsAuthenticated} />}
             />
-            <Route path="/App" element={<App/>}/>
 
           {/* Protected Routes */}
           <Route

--- a/parkquest-frontend/src/components/Header.jsx
+++ b/parkquest-frontend/src/components/Header.jsx
@@ -5,7 +5,7 @@ const Header = ({ isAuthenticated, onLogout }) => {
     return (
         <header>
             <h2 id="website-name">
-                <Link to={isAuthenticated ? "/dashboard" : "/app"} id="website-name">ParkQuest</Link>
+                <Link to={isAuthenticated ? "/dashboard" : "/"} id="website-name">ParkQuest</Link>
             </h2>
             <div>
                 {isAuthenticated ? (


### PR DESCRIPTION
This PR removes the unused /app route from the application.
Previously, if a user closed the website without logging off and then reopened it, they were redirected to a non-existent /app route. This caused a blank page and double header to appear due to the invalid route.